### PR TITLE
ci: Use cosign plugin to sign container images.

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -45,3 +45,28 @@ jobs:
           file: Dockerfile
           tags: ${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}:${{ env.Version}}
           labels: ${{ steps.meta-api.outputs.labels }}
+
+    outputs:
+      tags: ${{ steps.meta-api.outputs.tags }}
+
+  sign:
+    needs: build-and-push-image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.ref_name }}
+
+      - uses: sigstore/cosign-installer@main
+
+      - run: cosign sign -y -r ${TAGS}
+        env:
+          TAGS: ${{needs.build-and-push-image.outputs.tags}}


### PR DESCRIPTION
This commit adds cosign to the CI pipeline. cosign is an open-source tool developed by Chainguard that signs container images, allowing other users to cryptographically verify the origin of container images. [1]

cosign has different operating modes. This commit utilizes Chainguard's signing infrastructure via "keyless signing". [2] Keyless signing makes image signing easy for open-source projects because Chainguard operates the signing infrastructure on behalf of others.

Note: This commit is based on work by Chris Nesbitt-Smith, who published an example GitHub Actions workflow for running cosign. [3]

References

1. https://docs.sigstore.dev/signing/quickstart
2. https://edu.chainguard.dev/open-source/sigstore/cosign/an-introduction-to-cosign/#keyless-signing
3. https://github.com/chrisns/cosign-keyless-demo/blob/f35f6c776f/.github/workflows/ci.yml